### PR TITLE
fix: font application

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -35,7 +35,7 @@ export default function RootLayout({ children }) {
         <meta name="theme-color" media="(prefers-color-scheme: light)" content="#F6F6FA" />
         <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#09090A" />
       </head>
-      <body className={suit.className}>
+      <body className={suit.variable}>
         <GoogleOAuthProvider clientId="490381879-9976i94b3vvu2pabjttjgma8hscajrin.apps.googleusercontent.com">
           {children}
           <ToastContainer />


### PR DESCRIPTION
Previously, I confirmed that 'SUIT' font is not applied properly in ios safari environment and digital weathering phenomenon occurs. So, I changed the font application setting so that 'SUIT' font can be maintained in ios safari environment.

<img width="200px"  src="https://github.com/user-attachments/assets/f665a273-703b-4d9f-8344-206c10df563d"/>
<img width="200px" src="https://github.com/user-attachments/assets/bb0c3015-877c-440e-8da8-54bf781b17a3"/>
